### PR TITLE
Remove windowmanager binding as it is not supported in dab

### DIFF
--- a/app/app.pri
+++ b/app/app.pri
@@ -1,5 +1,12 @@
 TEMPLATE = app
 
 load(configure)
+qtCompileTest(libhomescreen)
+
+config_libhomescreen {
+    CONFIG += link_pkgconfig
+    PKGCONFIG += homescreen
+    DEFINES += HAVE_LIBHOMESCREEN
+}
 
 DESTDIR = $${OUT_PWD}/../package/root/bin

--- a/package/config.xml
+++ b/package/config.xml
@@ -6,8 +6,6 @@
   <description>This is a demo visclient application</description>
   <license>APL 2.0</license>
   <feature name="urn:AGL:widget:required-api">
-    <param name="windowmanager" value="ws"/>
-    <param name="homescreen" value="ws"/>
   </feature>
   <feature name="urn:AGL:widget:required-permission">
     <param name="urn:AGL:permission::public:no-htdocs" value="required"/>


### PR DESCRIPTION
Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>